### PR TITLE
Symmetric key decryption for messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,11 @@
       "resolved": "http://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
       "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
     },
+    "buffer-to-arraybuffer": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+      "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -224,6 +229,19 @@
         }
       }
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -233,6 +251,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "drbg.js": {
       "version": "1.0.1",
@@ -282,6 +305,16 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "requires": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
     },
     "ethereum-common": {
       "version": "0.2.1",
@@ -382,6 +415,14 @@
         "unpipe": "~1.0.0"
       }
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -391,6 +432,15 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
+      }
     },
     "has-flag": {
       "version": "3.0.0",
@@ -458,6 +508,16 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "isarray": {
       "version": "1.0.0",
@@ -537,6 +597,19 @@
         "mime-db": "~1.37.0"
       }
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -562,12 +635,49 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
+    "node-aes-gcm": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/node-aes-gcm/-/node-aes-gcm-0.2.4.tgz",
+      "integrity": "sha512-7xq0rowTgwO9ldwIOVVx5VzMHlA/rbiLQOV9xOBRKTWh/dJ1gwik78JM7riblgfx1AQa/+SifL/H8P4FbFGdvw==",
+      "requires": {
+        "nan": "2.8.x"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+        }
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "requires": {
         "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "parse-headers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
+      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
+      "requires": {
+        "for-each": "^0.3.2",
+        "trim": "0.0.1"
       }
     },
     "parseurl": {
@@ -579,6 +689,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -603,6 +718,16 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "randombytes": {
       "version": "2.0.6",
@@ -738,10 +863,30 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "requires": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -759,6 +904,16 @@
         "has-flag": "^3.0.0"
       }
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
     "type-is": {
       "version": "1.6.16",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
@@ -772,6 +927,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "url-set-query": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+      "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -788,6 +948,11 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
     "ws": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
@@ -795,6 +960,44 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xhr": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+      "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+      "requires": {
+        "global": "~4.3.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "xhr-request": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+      "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+      "requires": {
+        "buffer-to-arraybuffer": "^0.0.5",
+        "object-assign": "^4.1.1",
+        "query-string": "^5.0.1",
+        "simple-get": "^2.7.0",
+        "timed-out": "^4.0.1",
+        "url-set-query": "^1.0.0",
+        "xhr": "^2.0.4"
+      }
+    },
+    "xhr-request-promise": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
+      "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+      "requires": {
+        "xhr-request": "^1.0.1"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "crypto": "^1.0.1",
+    "elliptic": "^6.4.1",
+    "eth-lib": "^0.2.8",
     "ethereum-common": "^0.2.1",
     "ethereumjs-devp2p": "^2.5.0",
     "express": "^4.16.4",
     "express-ws": "^4.0.0",
     "lru-cache": "^4.1.3",
     "ms": "^2.1.1",
+    "node-aes-gcm": "^0.2.4",
     "rlp-encoding": "^3.0.0",
     "safe-buffer": "^5.1.2",
     "secp256k1": "^3.5.2"

--- a/src/messages.js
+++ b/src/messages.js
@@ -53,6 +53,13 @@ const decryptSymmetric = (topic, key, data, cb) => {
       throw err;
     }
 
+
+	if (data.length < aesNonceLength) {
+        const errorMsg = "missing salt or invalid payload in symmetric message";
+        if(cb) return cb(errorMsg);
+		throw errorMsg;
+	}
+
     const salt = data.slice(data.length - aesNonceLength);
     const msg = data.slice(0, data.length - 28);
     const decrypted = gcm.decrypt(key, salt, msg, Buffer.from([]), dummyAuthTag);

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,0 +1,108 @@
+const rlp = require('rlp-encoding')
+const crypto = require('crypto');
+const gcm = require('node-aes-gcm');
+const elliptic = require("elliptic");
+const secp256k1 = new elliptic.ec("secp256k1");
+const {keccak256} = require("eth-lib/lib/hash");
+const {slice, length, toNumber} = require("eth-lib/lib/bytes");
+
+// Extract to constants file?
+const aesNonceLength = 12;
+const dummyAuthTag = Buffer.from("11223344556677889900112233445566", 'hex');
+const flagMask = 3; // 0011
+const isSignedMask = 4; // 0100
+const signatureLength = 65; // bytes
+
+/**
+ * Convert a hex string to a byte array
+ * Note: Implementation from crypto-js
+ * @method hexToBytes
+ * @param {string} hex
+ * @return {Array} the byte array
+ */
+const hexToBytes = (hex) => {
+  hex = hex.toString(16);
+  hex = hex.replace(/^0x/i,'');
+  let bytes = [];
+  for (let c = 0; c < hex.length; c += 2)
+    bytes.push(parseInt(hex.substr(c, 2), 16));
+  return bytes;
+  };
+
+
+const assignDefined = (target, ...sources) => {
+  for (const source of sources) {
+    for (const key of Object.keys(source)) {
+      const val = source[key];
+      if (val !== undefined) {
+        target[key] = val;
+      }
+    }
+  }
+  return target;
+}
+
+const decryptAssymetric = (key, data, cb) => {
+    throw new Error("not implemented yet");
+}
+
+const decryptSymmetric = (topic, key, data, cb) => {
+  crypto.pbkdf2(topic, Buffer.from([]), 65536, aesNonceLength, 'sha256', (err, iv) => {
+    if (err) {
+      if(cb) return cb(err);
+      throw err;
+    }
+
+    const salt = data.slice(data.length - aesNonceLength);
+    const msg = data.slice(0, data.length - 28);
+    const decrypted = gcm.decrypt(key, salt, msg, Buffer.from([]), dummyAuthTag);
+
+    let start = 1;
+    const end = decrypted.plaintext.byteLength;
+
+    let payload;
+    let pubKey;
+
+    const auxiliaryFieldSize = decrypted.plaintext.readUIntLE(0, 1) & flagMask;
+    
+    let auxiliaryField; 
+    if(auxiliaryFieldSize !== 0) {
+      auxiliaryField = decrypted.plaintext.readUIntLE(start, auxiliaryFieldSize);
+      start += auxiliaryFieldSize;
+      payload = decrypted.plaintext.slice(start, start + auxiliaryField);
+    }
+
+    const isSigned = (decrypted.plaintext.readUIntLE(0, 1) & isSignedMask) == isSignedMask;
+    if(isSigned){   
+      const signature = getSignature(decrypted.plaintext);
+      const hash = getHash(decrypted.plaintext);
+      pubKey = ecRecoverPubKey(hash, signature);
+    }
+
+    if(cb){
+      return cb(null, assignDefined({}, {payload, pubKey}));
+    }
+  });
+}
+
+const getSignature = (plaintextBuffer) => "0x" + plaintextBuffer.slice(plaintextBuffer.length - signatureLength, plaintextBuffer.length).toString('hex');
+
+const getHash = (plaintextBuffer) => keccak256(hexToBytes(plaintextBuffer.slice(0, plaintextBuffer.length - signatureLength).toString('hex')));
+
+const ecRecoverPubKey = (messageHash, signature) => {
+// From eth-lib
+  const rsv = {
+    r: slice(0, 32, signature).slice(2),
+    s: slice(32, 64, signature).slice(2),
+    v: toNumber(slice(64, length(signature), signature))
+  } 
+
+  const ecPublicKey = secp256k1.recoverPubKey(new Buffer(messageHash.slice(2), "hex"), rsv, rsv.v < 2 ? rsv.v : 1 - rsv.v % 2);
+
+  return ecPublicKey.encode('hex');
+}
+
+
+module.exports = {
+    decryptSymmetric
+};


### PR DESCRIPTION
Allow the decryption of symmetric messages. Probably will blow if a non-symmetric message is sent. Better error handling will be implemented along with asymmetric decryption and `shh_getFilterMessages`

### How to use:
This example only works for messages received in #mytest. Key is hardcoded and must come from a keymanager. 
```
 if(topic.equals(Buffer.from("27ee704f", "hex"))){
          const messages = require('./messages');
          const key = Buffer.from("e0c69378eaa4845cd27036f7b77447c2ab0ede5389a178839bc2b44d8441d07c", "hex");

          messages.decryptSymmetric(topic, key, data, (err, res) => {
            console.log(err);
            console.log(res.pubKey.toString('hex'));
            console.log(res.payload.toString())
          })
}
```
